### PR TITLE
MAINT: pytest module for unit tests

### DIFF
--- a/test/mip_test.py
+++ b/test/mip_test.py
@@ -1,60 +1,19 @@
-"""Tests of Python-MIP framework, should be executed before each new
-release"""
-import sys, os
-
-sys.path.insert(0, os.getcwd())
-from itertools import product
+import pytest
 import networkx as nx
+from itertools import product
 from mip.model import Model, xsum
 from mip.constants import OptimizationStatus, MAXIMIZE, BINARY, INTEGER
 from mip.callbacks import ConstrsGenerator, CutPool
 
-has_colors = True
-try:
-    from termcolor import colored
-except ModuleNotFoundError:
-    has_colors = False
 
+TOL = 1E-4
 SOLVERS = ['CBC', 'Gurobi']
 
 
-def announce_test(descr: str, engine: str):
-    """print test starting message"""
-    if has_colors:
-        test = colored('> Test: ', 'cyan') + \
-               colored('{} '.format(descr), 'cyan',
-                       attrs=['bold']) + \
-               colored('    Solver engine: ', 'cyan') + \
-               colored('{} '.format(engine), 'cyan',
-                       attrs=['bold'])
-    else:
-        test = '> Test: {} Solver engine: {}'.format(descr, engine)
-
-    print(test)
-
-
-def check_result(descr: str, test: bool):
-    """executes a test and prints the result, raising exception
-    when fail"""
-
-    if test:
-        if has_colors:
-            text = '\t' + colored('{}'.format(descr), 'cyan') + \
-                   ' : ' + colored('OK', 'green')
-        else:
-            text = '\t' + '{} : OK'.format(descr)
-
-        print(text)
-    else:
-        print('\t{} : FAILED'.format(descr))
-        raise Exception("assert failed: {}".format(descr))
-
-
+@pytest.mark.parametrize("solver", SOLVERS)
 def test_queens(solver: str):
     """MIP model n-queens"""
     n = 50
-    announce_test("n-Queens", solver)
-
     queens = Model('queens', MAXIMIZE, solver_name=solver)
     queens.verbose = 0
 
@@ -80,30 +39,28 @@ def test_queens(solver: str):
                        if i + j == k) <= 1, 'diag2({})'.format(p)
 
     queens.optimize()
-
-    check_result("model status", queens.status == OptimizationStatus.OPTIMAL)
+    assert queens.status == OptimizationStatus.OPTIMAL  # "model status"
 
     # querying problem variables and checking opt results
     total_queens = 0
     for v in queens.vars:
         # basic integrality test
-        assert v.x <= 0.0001 or v.x >= 0.9999
+        assert v.x <= TOL or v.x >= 1 - TOL
         total_queens += v.x
 
     # solution feasibility
     rows_with_queens = 0
     for i in range(n):
-        if abs(sum(x[i][j].x for j in range(n)) - 1) <= 0.001:
+        if abs(sum(x[i][j].x for j in range(n)) - 1) <= TOL:
             rows_with_queens += 1
 
-    check_result("feasible solution", abs(total_queens - n) <= 0.001 and
-                 rows_with_queens == n)
-    print('')
+    assert abs(total_queens - n) <= TOL  # "feasible solution"
+    assert rows_with_queens == n         # "feasible solution"
 
 
+@pytest.mark.parametrize("solver", SOLVERS)
 def test_tsp(solver: str):
     """tsp related tests"""
-    announce_test("TSP - Compact", solver)
     N = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
     n = len(N)
     i0 = N[0]
@@ -144,20 +101,16 @@ def test_tsp(solver: str):
     m.relax()
     m.optimize()
 
-    check_result("lp model status", m.status == OptimizationStatus.OPTIMAL)
-    check_result("lp model objective", (abs(m.objective_value - 238.75))
-                 <= 1e-4)
+    assert m.status == OptimizationStatus.OPTIMAL  # "lp model status"
+    assert abs(m.objective_value - 238.75) <= TOL  # "lp model objective"
 
     # setting all variables to integer now
     for v in m.vars:
         v.var_type = INTEGER
-
     m.optimize()
 
-    check_result("mip model status", m.status == OptimizationStatus.OPTIMAL)
-    check_result("mip model objective", (abs(m.objective_value - 262)) <=
-                 0.0001)
-    print('')
+    assert m.status == OptimizationStatus.OPTIMAL  # "mip model status"
+    assert abs(m.objective_value - 262) <= TOL  # "mip model objective"
 
 
 class SubTourCutGenerator(ConstrsGenerator):
@@ -188,12 +141,11 @@ class SubTourCutGenerator(ConstrsGenerator):
                         return
         for cut in cp.cuts:
             model.add_cut(cut)
-        return
 
 
+@pytest.mark.parametrize("solver", SOLVERS)
 def test_tsp_cuts(solver: str):
     """tsp related tests"""
-    announce_test("TSP - Branch & Cut", solver)
     N = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
     n = len(N)
     i0 = N[0]
@@ -237,18 +189,15 @@ def test_tsp_cuts(solver: str):
     m.max_seconds = 10
     m.max_nodes = 100
     m.max_solutions = 1000
-
     m.optimize()
 
-    check_result("mip model status", m.status == OptimizationStatus.OPTIMAL)
-    check_result("mip model objective", (abs(m.objective_value - 262)) <=
-                 0.0001)
-    print('')
+    assert m.status == OptimizationStatus.OPTIMAL  # "mip model status"
+    assert abs(m.objective_value - 262) <= TOL     # "mip model objective"
 
 
+@pytest.mark.parametrize("solver", SOLVERS)
 def test_tsp_mipstart(solver: str):
     """tsp related tests"""
-    announce_test("TSP - MIPStart", solver)
     N = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
     n = len(N)
     i0 = N[0]
@@ -290,48 +239,58 @@ def test_tsp_mipstart(solver: str):
     m.start = [(x[route[i - 1], route[i]], 1.0) for i in range(1, len(route))]
     m.optimize()
 
-    check_result("mip model status", m.status == OptimizationStatus.OPTIMAL)
-    check_result("mip model objective", (abs(m.objective_value - 262)) <=
-                 0.0001)
-    print('')
+    assert m.status == OptimizationStatus.OPTIMAL
+    assert abs(m.objective_value - 262) <= TOL
 
 
-print("")
-if has_colors:
-    print(colored("=======================================",
-                  "green", attrs=["bold"]))
-    print("")
-    print(colored("      Starting Automated Tests",
-                  "green", attrs=["bold"]))
-    print("")
-    print(colored("=======================================",
-                  "green", attrs=["bold"]))
-else:
-    print("=======================================")
-    print("")
-    print("       Starting Automated Tests")
-    print("")
-    print("=======================================")
-for svr in SOLVERS:
-    test_queens(svr)
-    test_tsp(svr)
-    test_tsp_cuts(svr)
-    test_tsp_mipstart(svr)
+class TestCBC(object):
 
-print("")
-if has_colors:
-    print(colored("=======================================",
-                  "green", attrs=["bold"]))
-    print("")
-    print(colored("            All test passed", "green", attrs=["bold"]))
-    print(colored("                   :^)", "green", attrs=["bold"]))
-    print("")
-    print(colored("=======================================",
-                  "green", attrs=["bold"]))
-else:
-    print("=======================================")
-    print("")
-    print("            All test passed")
-    print("                  :^)")
-    print("")
-    print("=======================================")
+    def build_model(self, solver):
+        """MIP model n-queens"""
+        n = 50
+        queens = Model('queens', MAXIMIZE, solver_name=solver)
+        queens.verbose = 0
+
+        x = [[queens.add_var('x({},{})'.format(i, j), var_type=BINARY)
+              for j in range(n)] for i in range(n)]
+
+        # one per row
+        for i in range(n):
+            queens += xsum(x[i][j] for j in range(n)) == 1, 'row({})'.format(i)
+
+        # one per column
+        for j in range(n):
+            queens += xsum(x[i][j] for i in range(n)) == 1, 'col({})'.format(j)
+
+        # diagonal \
+        for p, k in enumerate(range(2 - n, n - 2 + 1)):
+            queens += xsum(x[i][j] for i in range(n) for j in range(n)
+                           if i - j == k) <= 1, 'diag1({})'.format(p)
+
+        # diagonal /
+        for p, k in enumerate(range(3, n + n)):
+            queens += xsum(x[i][j] for i in range(n) for j in range(n)
+                           if i + j == k) <= 1, 'diag2({})'.format(p)
+        return queens
+
+    @pytest.mark.parametrize("solver", SOLVERS)
+    def test_constr_get_index(self, solver):
+        model = self.build_model(solver)
+
+        idx = model.solver.constr_get_index('row(0)')
+        assert idx >= 0
+
+        idx = model.solver.constr_get_index('col(0)')
+        assert idx >= 0
+
+    @pytest.mark.parametrize("solver", SOLVERS)
+    def test_remove_constrs(self, solver):
+        model = self.build_model(solver)
+
+        idx1 = model.solver.constr_get_index('row(0)')
+        assert idx1 >= 0
+
+        idx2 = model.solver.constr_get_index('col(0)')
+        assert idx2 >= 0
+
+        model.solver.remove_constrs([idx1, idx2])

--- a/test/mip_test.py
+++ b/test/mip_test.py
@@ -256,11 +256,11 @@ class TestCBC(object):
 
         # one per row
         for i in range(n):
-            queens += xsum(x[i][j] for j in range(n)) == 1, 'row({})'.format(i)
+            queens += xsum(x[i][j] for j in range(n)) == 1, 'row{}'.format(i)
 
         # one per column
         for j in range(n):
-            queens += xsum(x[i][j] for i in range(n)) == 1, 'col({})'.format(j)
+            queens += xsum(x[i][j] for i in range(n)) == 1, 'col{}'.format(j)
 
         # diagonal \
         for p, k in enumerate(range(2 - n, n - 2 + 1)):
@@ -271,26 +271,30 @@ class TestCBC(object):
         for p, k in enumerate(range(3, n + n)):
             queens += xsum(x[i][j] for i in range(n) for j in range(n)
                            if i + j == k) <= 1, 'diag2({})'.format(p)
+
+        if solver.upper() in ['GUROBI', 'GRB']:
+            queens.solver.update()
+
         return queens
 
     @pytest.mark.parametrize("solver", SOLVERS)
     def test_constr_get_index(self, solver):
         model = self.build_model(solver)
 
-        idx = model.solver.constr_get_index('row(0)')
+        idx = model.solver.constr_get_index('row0')
         assert idx >= 0
 
-        idx = model.solver.constr_get_index('col(0)')
+        idx = model.solver.constr_get_index('col0')
         assert idx >= 0
 
     @pytest.mark.parametrize("solver", SOLVERS)
     def test_remove_constrs(self, solver):
         model = self.build_model(solver)
 
-        idx1 = model.solver.constr_get_index('row(0)')
+        idx1 = model.solver.constr_get_index('row0')
         assert idx1 >= 0
 
-        idx2 = model.solver.constr_get_index('col(0)')
+        idx2 = model.solver.constr_get_index('col0')
         assert idx2 >= 0
 
         model.solver.remove_constrs([idx1, idx2])


### PR DESCRIPTION
First off, this module is really great.

I have had an issue with calls to CBC library functions failing, which can be caught with testing. In order to make adding tests easier, I propose using `pytest` as a testing framework. It is quite widely used - the numpy and scipy projects use it too.

In this PR I have adapted the tests to use `pytest`. You can run them with `pytest -v mip_test.py`.
I have also added a test which demonstrates the problem in #27. You can add a test case each time an issue like this is fixed so it doesn't crop up again.

