### PR TITLE
MAINT: reverted minimum python version to 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mip",
-    python_requires='>3.6.0',
+    python_requires='>3.5.0',
     version=VERSION,
     author="Santos, H.G. and Toffolo, T.A.M.",
     author_email="haroldo@ufop.edu.br",


### PR DESCRIPTION
Closes: #33

I have checked all the type hints by hand. There do not appear to be any which do not work with python 3.5.