### PR TITLE
[MRG] Updates to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ install:
     - pip install .
 script:
     - pytest test --verbose --color=yes --doctest-modules
+    - pytest mip --verbose --color=yes --doctest-modules --ignore-glob="*gurobi.py"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ python:
 cache: pip
 install:
     - pip install cffi pytest networkx
+    - pip install .
 script:
-    - export PYTHONPATH=$PYTHONPATH:$(pwd) ; cd test ; python -m pytest
+    - pytest test --verbose --color=yes --doctest-modules
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
+    - "3.5"
     - "3.6"
+    - "3.7"
 cache: pip
 install:
     - pip install cffi pytest networkx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+cache: pip
 install:
-    - pip install cffi pytest networkx
+    - pip install cffi pytest flake8 networkx
     - pip install .
 script:
+    - flake8 mip --select=F401 --exclude=__init__.py # Look for unused imports
     - pytest test --verbose --color=yes --doctest-modules
-    - pytest mip --verbose --color=yes --doctest-modules --ignore-glob="*gurobi.py"
+    - pytest mip --verbose --color=yes --doctest-modules --ignore="mip/gurobi.py"
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
-cache: pip
 install:
     - pip install cffi pytest networkx
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ script:
     - flake8 mip --select=F401 --exclude=__init__.py # Look for unused imports
     - pytest test --verbose --color=yes --doctest-modules
     - pytest mip --verbose --color=yes --doctest-modules --ignore="mip/gurobi.py"
+    - # Ensure that the examples used in the docs run (TODO: Generalize this)
+    - python examples/knapsack.py
+    - python examples/tsp-compact.py
     

--- a/mip/lists.py
+++ b/mip/lists.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from typing import List
-from mip.constants import BINARY, CONTINUOUS, INTEGER, INF
+from mip.constants import BINARY, CONTINUOUS, INF
 from mip.entities import Column, Constr, LinExpr, Var
 
 

--- a/mip/log.py
+++ b/mip/log.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+
 
 class ProgressLog:
     """Class to store the improvement of lower

--- a/mip/model.py
+++ b/mip/model.py
@@ -25,6 +25,17 @@ class Model:
     Attributes:
         vars(VarList): list of problem variables (:class:`~mip.model.Var`)
         constrs(ConstrList): list of constraints (:class:`~mip.model.Constr`)
+        
+    Examples:
+        >>> from mip import Model, MAXIMIZE, CBC, INTEGER, OptimizationStatus
+        >>> model = Model(sense=MAXIMIZE, solver_name=CBC)
+        >>> x = model.add_var(name='x', var_type=INTEGER, lb=0, ub=10)
+        >>> y = model.add_var(name='y', var_type=INTEGER, lb=0, ub=10)
+        >>> model += x + y <= 10
+        >>> model.objective = x + y
+        >>> status = model.optimize(max_seconds=2)
+        >>> status == OptimizationStatus.OPTIMAL
+        True
     """
 
     def __init__(self, name: str = "",

--- a/mip/model.py
+++ b/mip/model.py
@@ -1,6 +1,6 @@
 from os import environ
 from os.path import isfile
-from sys import stdout as out, platform
+from sys import stdout as out
 from typing import List, Tuple, Optional, Union, Dict
 
 from mip.constants import *

--- a/mip/solver.py
+++ b/mip/solver.py
@@ -2,7 +2,7 @@
 Python-MIP
 """
 from math import inf
-from typing import List, Tuple, Optional
+from typing import List, Tuple
 from mip.constants import INF, CONTINUOUS
 from mip.constants import SearchEmphasis, OptimizationStatus
 


### PR DESCRIPTION
- README claims the package is for Python 3.5+, so we now test py35, 36 and 37.
- Added a doctest to the Model class to show usage. "pytest" will run this now.
- Added a check for unused imports with "flake8" to show how to use it. A full flake8 run (`flake8 mip`) returns 171 warnings. I didn't want to address all of these in a single PR.
- Added two examples from the docs to travis. The idea is that if some change to the library will make these examples fail in the future, this will be immediately caught. Again I could've added more, but I only added 2 examples now. I don't want to address everything in a single PR.