### PR TITLE
Remove writing to stdout/stderr and use python logging instead

### DIFF
--- a/mip/cbc.py
+++ b/mip/cbc.py
@@ -1,7 +1,8 @@
 """Python-MIP interface to the COIN-OR Branch-and-Cut solver CBC"""
 
+import logging
 from typing import Dict, List, Tuple, Optional
-from sys import platform, maxsize, stdout as out, stderr as err
+from sys import platform, maxsize
 from os.path import dirname, isfile
 import os
 import multiprocessing as multip
@@ -33,6 +34,7 @@ from mip import (
     CutPool,
 )
 
+logger = logging.getLogger(__name__)
 warningMessages = 0
 
 ffi = FFI()
@@ -87,8 +89,9 @@ try:
     os.chdir(old_dir)
     has_cbc = True
 except Exception as e:
-    err.write("\nAn error occurred while loading the CBC library:\n")
-    err.write("\t" + str(e) + "\n")
+    logger.error(
+        "An error occurred while loading the CBC library:\t " "{}\n".format(e)
+    )
     has_cbc = False
 
 if has_cbc:
@@ -713,14 +716,15 @@ class SolverCbc(Solver):
             cut_types = [e for e in CutType]
         for cut_type in cut_types:
             if self.__verbose >= 1:
-                out.write(
-                    "searching for violated {} cuts ... ".format(cut_type.name)
+                logger.info(
+                    "searching for violated "
+                    "{} cuts ... ".format(cut_type.name)
                 )
             nc1 = OsiCuts_sizeRowCuts(osi_cuts)
             Cgl_generateCuts(osi_solver, int(cut_type.value), osi_cuts, int(1))
             nc2 = OsiCuts_sizeRowCuts(osi_cuts)
             if self.__verbose >= 1:
-                out.write("{} found.\n".format(nc2 - nc1))
+                logger.info("{} found.\n".format(nc2 - nc1))
             if OsiCuts_sizeRowCuts(osi_cuts) >= max_cuts:
                 break
 

--- a/mip/gurobi.py
+++ b/mip/gurobi.py
@@ -1,4 +1,5 @@
 from ctypes.util import find_library
+import logging
 from sys import maxsize
 from typing import List, Tuple
 from os.path import isfile
@@ -30,6 +31,7 @@ from mip import (
     LP_Method,
 )
 
+logger = logging.getLogger(__name__)
 
 try:
     found = False
@@ -87,7 +89,7 @@ try:
     ffi = FFI()
 
     grblib = ffi.dlopen(lib_path)
-    print("gurobi version {}.{} found".format(major_ver, minor_ver))
+    logger.warning("gurobi version {}.{} found".format(major_ver, minor_ver))
 except Exception:
     raise ImportError
 
@@ -588,7 +590,7 @@ class SolverGurobi(Solver):
                                     difl = abs(obj_bound - log[-1][1][0])
                                     difu = abs(obj_best - log[-1][1][1])
                                     if difl >= 1e-6 or difu >= 1e-6:
-                                        print(
+                                        logger.info(
                                             ">>>>>>> {} {}".format(
                                                 obj_bound, obj_best
                                             )


### PR DESCRIPTION
This is an update of #54 
It replaces the uses of stdout and stderr by the logging module.

fixes #50 

There are still logs from CBC itself I'm not able to remove (even when setting "verbose" to 0):
"Coin3009W Conflict graph built in XXX seconds, density: YYY%"
and
"Cgl0015I Clique Strengthening extended X cliques, Y were dominated"