### PR TITLE
Make exceptions and asserts specific

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -81,6 +81,18 @@ ProgressLog
 .. autoclass:: mip.model.ProgressLog
     :members:
 
+Exceptions
+-----------
+
+.. autoclass:: mip.exceptions.MipBaseException
+.. autoclass:: mip.exceptions.ProgrammingError
+.. autoclass:: mip.exceptions.InterfacingError
+.. autoclass:: mip.exceptions.InvalidLinExpr
+.. autoclass:: mip.exceptions.InvalidParameter
+.. autoclass:: mip.exceptions.ParameterNotAvailable
+.. autoclass:: mip.exceptions.InfeasibleSolution
+.. autoclass:: mip.exceptions.SolutionNotAvailable
+
 Useful functions
 ----------------
 

--- a/mip/__init__.py
+++ b/mip/__init__.py
@@ -4,11 +4,7 @@ from mip.model import *
 from mip.callbacks import *
 from mip.log import ProgressLog
 from mip.lists import ConstrList, VarList, VConstrList, VVarList
-from mip.exceptions import (
-    InvalidLinExpr,
-    InvalidParameter,
-    ParameterNotAvailable,
-)
+from mip.exceptions import *
 from mip.solver import Solver
 
 __version__ = VERSION

--- a/mip/cbc.py
+++ b/mip/cbc.py
@@ -10,6 +10,12 @@ from cffi import FFI
 from mip.model import xsum
 import mip
 from mip.lists import EmptyVarSol, EmptyRowSol
+from mip.exceptions import (
+    ParameterNotAvailable,
+    SolutionNotAvailable,
+    ProgrammingError,
+    InterfacingError,
+)
 from mip import (
     Model,
     Var,
@@ -67,7 +73,9 @@ try:
                 pathlib = os.path.join(pathlib, "lin64")
                 libfile = os.path.join(pathlib, "libCbcSolver.so")
             else:
-                raise Exception("Linux 32 bits platform not supported.")
+                raise NotImplementedError(
+                    "Linux 32 bits platform not supported."
+                )
         elif platform.lower().startswith("win"):
             if os_is_64_bit:
                 pathlib = os.path.join(pathlib, "win64")
@@ -75,14 +83,16 @@ try:
                     os.environ["PATH"] = pathlib + ";" + os.environ["PATH"]
                 libfile = os.path.join(pathlib, "libCbcSolver-0.dll")
             else:
-                raise Exception("Win32 platform not supported.")
+                raise NotImplementedError("Win32 platform not supported.")
         elif platform.lower().startswith(
             "darwin"
         ) or platform.lower().startswith("macos"):
             if os_is_64_bit:
                 libfile = os.path.join(pathlib, "cbc-c-darwin-x86-64.dylib")
         if not libfile:
-            raise Exception("You operating system/platform is not supported")
+            raise NotImplementedError(
+                "You operating system/platform is not supported"
+            )
     old_dir = os.getcwd()
     os.chdir(pathlib)
     cbclib = ffi.dlopen(libfile)
@@ -623,7 +633,9 @@ class SolverCbc(Solver):
     def get_objective(self) -> LinExpr:
         obj = cbclib.Cbc_getObjCoefficients(self._model)
         if obj == ffi.NULL:
-            raise Exception("Error getting objective function coefficients")
+            raise ParameterNotAvailable(
+                "Error getting objective function coefficients"
+            )
         return (
             xsum(
                 obj[j] * self.model.vars[j]
@@ -740,7 +752,7 @@ class SolverCbc(Solver):
             elif rsense == "G":
                 sense = GREATER_OR_EQUAL
             else:
-                raise Exception("Unknow sense: {}".format(rsense))
+                raise ValueError("Unknow sense: {}".format(rsense))
             idx = OsiCuts_idxRowCut(osi_cuts, i)
             coef = OsiCuts_coefRowCut(osi_cuts, i)
             nz = OsiCuts_nzRowCut(osi_cuts, i)
@@ -1017,7 +1029,7 @@ class SolverCbc(Solver):
         elif sense.strip().upper() == MINIMIZE.strip().upper():
             cbclib.Cbc_setObjSense(self._model, 1.0)
         else:
-            raise Exception(
+            raise ValueError(
                 "Unknown sense: {}, use {} or {}".format(
                     sense, MAXIMIZE, MINIMIZE
                 )
@@ -1076,7 +1088,9 @@ class SolverCbc(Solver):
     def var_get_lb(self, var: "Var") -> float:
         lb = cbclib.Cbc_getColLower(self._model)
         if lb == ffi.NULL:
-            raise Exception("Error while getting lower bound of variables")
+            raise ParameterNotAvailable(
+                "Error while getting lower bound of variables"
+            )
         return float(lb[var.idx])
 
     def var_set_lb(self, var: "Var", value: float):
@@ -1085,7 +1099,9 @@ class SolverCbc(Solver):
     def var_get_ub(self, var: "Var") -> float:
         ub = cbclib.Cbc_getColUpper(self._model)
         if ub == ffi.NULL:
-            raise Exception("Error while getting upper bound of variables")
+            raise ParameterNotAvailable(
+                "Error while getting upper bound of variables"
+            )
         return float(ub[var.idx])
 
     def var_set_ub(self, var: "Var", value: float):
@@ -1111,7 +1127,9 @@ class SolverCbc(Solver):
     def var_get_obj(self, var: Var) -> float:
         obj = cbclib.Cbc_getObjCoefficients(self._model)
         if obj == ffi.NULL:
-            raise Exception("Error getting objective function coefficients")
+            raise ParameterNotAvailable(
+                "Error getting objective function coefficients"
+            )
         return obj[var.idx]
 
     def var_get_var_type(self, var: "Var") -> str:
@@ -1131,7 +1149,7 @@ class SolverCbc(Solver):
 
         cidx = cbclib.Cbc_getColIndices(self._model, var.idx)
         if cidx == ffi.NULL:
-            raise Exception("Error getting column indices'")
+            raise ParameterNotAvailable("Error getting column indices'")
         ccoef = cbclib.Cbc_getColCoeffs(self._model, var.idx)
 
         col = Column()
@@ -1199,14 +1217,16 @@ class SolverCbc(Solver):
         elif ".lp" in file_path.lower():
             cbclib.Cbc_writeLp(self._model, fpstr)
         else:
-            raise Exception(
+            raise ValueError(
                 "Enter a valid extension (.lp or .mps) \
                 to indicate the file format"
             )
 
     def read(self, file_path: str) -> None:
         if not isfile(file_path):
-            raise Exception("File {} does not exists".format(file_path))
+            raise FileNotFoundError(
+                "File {} does not exists".format(file_path)
+            )
 
         fpstr = file_path.encode("utf-8")
         if ".mps" in file_path.lower():
@@ -1214,7 +1234,7 @@ class SolverCbc(Solver):
         elif ".lp" in file_path.lower():
             cbclib.Cbc_readLp(self._model, fpstr)
         else:
-            raise Exception(
+            raise ValueError(
                 "Enter a valid extension (.lp or .mps) \
                 to indicate the file format"
             )
@@ -1264,10 +1284,10 @@ class SolverCbc(Solver):
 
         ridx = cbclib.Cbc_getRowIndices(self._model, constr.idx)
         if ridx == ffi.NULL:
-            raise Exception("Error getting row indices.")
+            raise ParameterNotAvailable("Error getting row indices.")
         rcoef = cbclib.Cbc_getRowCoeffs(self._model, constr.idx)
         if rcoef == ffi.NULL:
-            raise Exception("Error getting row coefficients.")
+            raise ParameterNotAvailable("Error getting row coefficients.")
 
         rhs = cbclib.Cbc_getRowRHS(self._model, constr.idx)
         rsense = (
@@ -1283,7 +1303,7 @@ class SolverCbc(Solver):
         elif rsense == "G":
             sense = GREATER_OR_EQUAL
         else:
-            raise Exception("Unknow sense: {}".format(rsense))
+            raise ValueError("Unknow sense: {}".format(rsense))
 
         expr = LinExpr(const=-rhs, sense=sense)
         for i in range(numnz):
@@ -1553,12 +1573,14 @@ class SolverOsi(Solver):
             self.add_constr(lin_expr, name)
 
     def get_objective_bound(self) -> float:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_objective(self) -> LinExpr:
         obj = cbclib.Osi_getObjCoefficients(self.osi)
         if obj == ffi.NULL:
-            raise Exception("Error getting objective function coefficients")
+            raise ParameterNotAvailable(
+                "Error getting objective function coefficients"
+            )
         return (
             xsum(
                 obj[j] * self.model.vars[j]
@@ -1604,7 +1626,7 @@ class SolverOsi(Solver):
         return []
 
     def get_objective_value_i(self, i: int) -> float:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_num_solutions(self) -> int:
         if cbclib.Osi_isProvenOptimal(self.osi):
@@ -1625,14 +1647,14 @@ class SolverOsi(Solver):
         elif sense.strip().upper() == MINIMIZE.strip().upper():
             cbclib.Osi_setObjSense(self.osi, 1.0)
         else:
-            raise Exception(
+            raise ValueError(
                 "Unknown sense: {}, use {} or {}".format(
                     sense, MAXIMIZE, MINIMIZE
                 )
             )
 
     def set_start(self, start: List[Tuple["Var", float]]):
-        raise Exception("MIPstart not available in OsiSolver")
+        raise NotImplementedError("MIPstart not available in OsiSolver")
 
     def set_objective(self, lin_expr: "LinExpr", sense: str = ""):
         # collecting variable coefficients
@@ -1649,7 +1671,7 @@ class SolverOsi(Solver):
             cbclib.Osi_setObjSense(self.osi, 1.0)
 
     def set_objective_const(self, const: float):
-        raise Exception("Still not implemented in OsiSolver")
+        raise NotImplementedError("Still not implemented in OsiSolver")
 
     def set_processing_limits(
         self,
@@ -1657,40 +1679,40 @@ class SolverOsi(Solver):
         max_nodes: int = maxsize,
         max_sol: int = maxsize,
     ):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_max_seconds(self) -> float:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_max_seconds(self, max_seconds: float):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_max_solutions(self) -> int:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_max_solutions(self, max_solutions: int):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_pump_passes(self) -> int:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_pump_passes(self, passes: int):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_max_nodes(self) -> int:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_max_nodes(self, max_nodes: int):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_num_threads(self, threads: int):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def write(self, file_path: str):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def read(self, file_path: str):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def num_cols(self) -> int:
         return cbclib.Osi_getNumCols(self.osi)
@@ -1705,34 +1727,34 @@ class SolverOsi(Solver):
         return cbclib.Osi_getNumIntegers(self.osi)
 
     def get_emphasis(self) -> SearchEmphasis:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_emphasis(self, emph: SearchEmphasis):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_cutoff(self) -> float:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_cutoff(self, cutoff: float):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_mip_gap_abs(self) -> float:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_mip_gap_abs(self, mip_gap_abs: float):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_mip_gap(self) -> float:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_mip_gap(self, mip_gap: float):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def get_verbose(self) -> int:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def set_verbose(self, verbose: int):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     # Constraint-related getters/setters
     def constr_get_expr(self, constr: Constr) -> LinExpr:
@@ -1740,10 +1762,10 @@ class SolverOsi(Solver):
 
         ridx = cbclib.Osi_getRowIndices(self.osi, constr.idx)
         if ridx == ffi.NULL:
-            raise Exception("Error getting row indices.")
+            raise ParameterNotAvailable("Error getting row indices.")
         rcoef = cbclib.Osi_getRowCoeffs(self.osi, constr.idx)
         if rcoef == ffi.NULL:
-            raise Exception("Error getting row coefficients.")
+            raise ParameterNotAvailable("Error getting row coefficients.")
 
         rhs = cbclib.Osi_getRowRHS(self.osi, constr.idx)
         rsense = (
@@ -1759,7 +1781,7 @@ class SolverOsi(Solver):
         elif rsense == "G":
             sense = GREATER_OR_EQUAL
         else:
-            raise Exception("Unknow sense: {}".format(rsense))
+            raise ValueError("Unknow sense: {}".format(rsense))
 
         expr = LinExpr(const=-rhs, sense=sense)
         for i in range(numnz):
@@ -1768,7 +1790,7 @@ class SolverOsi(Solver):
         return expr
 
     def constr_set_expr(self, constr: Constr, value: LinExpr) -> LinExpr:
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def constr_get_name(self, idx: int) -> str:
         namep = self.__name_space
@@ -1776,7 +1798,7 @@ class SolverOsi(Solver):
         return ffi.string(namep).decode("utf-8")
 
     def remove_constrs(self, constrsList: List[int]):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def constr_get_index(self, name: str) -> int:
         if self.rowNames is None:
@@ -1842,7 +1864,9 @@ class SolverOsi(Solver):
     def var_get_obj(self, var: "Var") -> float:
         obj = cbclib.Osi_getObjCoefficients(self.osi)
         if obj == ffi.NULL:
-            raise Exception("Error getting objective function coefficients")
+            raise ParameterNotAvailable(
+                "Error getting objective function coefficients"
+            )
         return obj[var.idx]
 
     def var_set_obj(self, var: "Var", value: float):
@@ -1882,7 +1906,7 @@ class SolverOsi(Solver):
 
         cidx = cbclib.Cbc_getColIndices(self.osi, var.idx)
         if cidx == ffi.NULL:
-            raise Exception("Error getting column indices'")
+            raise ParameterNotAvailable("Error getting column indices'")
         ccoef = cbclib.Cbc_getColCoeffs(self.osi, var.idx)
 
         col = Column()
@@ -1894,22 +1918,22 @@ class SolverOsi(Solver):
         return col
 
     def var_set_column(self, var: "Var", value: Column):
-        raise Exception("Not available in OsiSolver")
+        raise NotImplementedError("Not available in OsiSolver")
 
     def var_get_rc(self, var: "Var") -> float:
         rc = cbclib.Osi_getReducedCost(self.osi)
         if rc == ffi.NULL:
-            raise Exception("reduced cost not available")
+            raise ParameterNotAvailable("reduced cost not available")
         return float(rc[var.idx])
 
     def var_get_x(self, var: "Var") -> float:
         x = cbclib.Osi_getColSolution(self.osi)
         if x == ffi.NULL:
-            raise Exception("no solution found")
+            raise SolutionNotAvailable("no solution found")
         return float(x[var.idx])
 
     def var_get_xi(self, var: "Var", i: int) -> float:
-        raise Exception("Solution pool not supported in OsiSolver")
+        raise NotImplementedError("Solution pool not supported in OsiSolver")
 
     def var_get_name(self, idx: int) -> str:
         namep = self.__name_space
@@ -1917,7 +1941,7 @@ class SolverOsi(Solver):
         return ffi.string(namep).decode("utf-8")
 
     def remove_vars(self, varsList: List[int]):
-        raise Exception("Not supported in OsiSolver")
+        raise NotImplementedError("Not supported in OsiSolver")
 
     def var_get_index(self, name: str) -> int:
         if self.colNames is None:
@@ -1931,10 +1955,10 @@ class SolverOsi(Solver):
         return -1
 
     def get_problem_name(self) -> str:
-        raise Exception("Not supported in OsiSolver")
+        raise NotImplementedError("Not supported in OsiSolver")
 
     def set_problem_name(self, name: str):
-        raise Exception("Not supported in OsiSolver")
+        raise NotImplementedError("Not supported in OsiSolver")
 
 
 # vim: ts=4 sw=4 et

--- a/mip/cbc.py
+++ b/mip/cbc.py
@@ -13,8 +13,6 @@ from mip.lists import EmptyVarSol, EmptyRowSol
 from mip.exceptions import (
     ParameterNotAvailable,
     SolutionNotAvailable,
-    ProgrammingError,
-    InterfacingError,
 )
 from mip import (
     Model,

--- a/mip/entities.py
+++ b/mip/entities.py
@@ -74,7 +74,10 @@ class LinExpr:
         self.__sense = sense
 
         if variables:
-            assert len(variables) == len(coeffs)
+            if len(variables) != len(coeffs):
+                raise ValueError(
+                    "Coefficients and variables must be same length."
+                )
             for i in range(len(coeffs)):
                 if abs(coeffs[i]) <= 1e-12:
                     continue
@@ -137,7 +140,10 @@ class LinExpr:
         return self
 
     def __mul__(self: "LinExpr", other: Union[numbers.Real]) -> "LinExpr":
-        assert isinstance(other, numbers.Real)
+        if not isinstance(other, numbers.Real):
+            raise TypeError(
+                "Can not multiply with type {}".format(type(other))
+            )
         result = self.copy()
         result.__const *= other
         for var in result.__expr.keys():
@@ -148,14 +154,18 @@ class LinExpr:
         return self.__mul__(other)
 
     def __imul__(self: "LinExpr", other: Union[numbers.Real]) -> "LinExpr":
-        assert isinstance(other, numbers.Real)
+        if not isinstance(other, numbers.Real):
+            raise TypeError(
+                "Can not multiply with type {}".format(type(other))
+            )
         self.__const *= other
         for var in self.__expr.keys():
             self.__expr[var] *= other
         return self
 
     def __truediv__(self: "LinExpr", other: Union[numbers.Real]) -> "LinExpr":
-        assert isinstance(other, numbers.Real)
+        if not isinstance(other, numbers.Real):
+            raise TypeError("Can not divide with type {}".format(type(other)))
         result = self.copy()
         result.__const /= other
         for var in result.__expr.keys():
@@ -163,7 +173,8 @@ class LinExpr:
         return result
 
     def __itruediv__(self: "LinExpr", other: Union[numbers.Real]) -> "LinExpr":
-        assert isinstance(other, numbers.Real)
+        if not isinstance(other, numbers.Real):
+            raise TypeError("Can not divide with type {}".format(type(other)))
         self.__const /= other
         for var in self.__expr.keys():
             self.__expr[var] /= other
@@ -482,14 +493,18 @@ class Var:
             return LinExpr([self], [-1], other)
 
     def __mul__(self, other: Union[numbers.Real]) -> LinExpr:
-        assert isinstance(other, numbers.Real)
+        if not isinstance(other, numbers.Real):
+            raise TypeError(
+                "Can not multiply with type {}".format(type(other))
+            )
         return LinExpr([self], [other])
 
     def __rmul__(self, other: Union[numbers.Real]) -> LinExpr:
         return self.__mul__(other)
 
     def __truediv__(self, other: Union[numbers.Real]) -> LinExpr:
-        assert isinstance(other, numbers.Real)
+        if not isinstance(other, numbers.Real):
+            raise TypeError("Can not divide with type {}".format(type(other)))
         return self.__mul__(1.0 / other)
 
     def __neg__(self) -> LinExpr:
@@ -567,7 +582,12 @@ class Var:
 
     @var_type.setter
     def var_type(self, value: str):
-        assert value in (BINARY, CONTINUOUS, INTEGER)
+        if value not in (BINARY, CONTINUOUS, INTEGER):
+            raise ValueError(
+                "Expected one of {}, but got {}".format(
+                    (BINARY, CONTINUOUS, INTEGER), value
+                )
+            )
         self.__model.solver.var_set_var_type(self, value)
 
     @property

--- a/mip/exceptions.py
+++ b/mip/exceptions.py
@@ -1,26 +1,49 @@
 """Python-MIP Exceptions"""
 
 
-class InvalidLinExpr(Exception):
+class MipBaseException(Exception):
+    """Base class for all exceptions specific to Python MIP. Only sub-classes
+    of this exception are raised.
+    Inherits from the Python builtin ``Exception``."""
+
+
+class ProgrammingError(MipBaseException):
+    """Exception that is raised when the calling program performs an invalid
+     or nonsensical operation.
+     Inherits from :attr:`~mip.exceptions.MipBaseException`."""
+
+
+class InterfacingError(MipBaseException):
+    """Exception that is raised when an unknown error occurs while interfacing
+    with a solver.
+    Inherits from :attr:`~mip.exceptions.MipBaseException`."""
+
+
+class InvalidLinExpr(MipBaseException):
     """Exception that is raised when an invalid
-    linear expression is created"""
+    linear expression is created.
+    Inherits from :attr:`~mip.exceptions.MipBaseException`."""
 
 
-class InvalidParameter(Exception):
+class InvalidParameter(MipBaseException):
     """Exception that is raised when an invalid/non-existent
-    parameter is used or set"""
+    parameter is used or set.
+    Inherits from :attr:`~mip.exceptions.MipBaseException`."""
 
 
-class ParameterNotAvailable(Exception):
+class ParameterNotAvailable(MipBaseException):
     """Exception that is raised when some parameter is not
-    available for the current solver"""
+    available or can not be set.
+    Inherits from :attr:`~mip.exceptions.MipBaseException`."""
 
 
-class InfeasibleSolution(Exception):
+class InfeasibleSolution(MipBaseException):
     """Exception that is raised the produced solution
-    is unfeasible"""
+    is unfeasible.
+    Inherits from :attr:`~mip.exceptions.MipBaseException`."""
 
 
-class SolutionNotAvailable(Exception):
+class SolutionNotAvailable(MipBaseException):
     """Exception that is raised when a method that requires
-    a solution is queried but the solution is not available"""
+    a solution is queried but the solution is not available.
+    Inherits from :attr:`~mip.exceptions.MipBaseException`."""

--- a/mip/lists.py
+++ b/mip/lists.py
@@ -124,7 +124,7 @@ class VVarList(Sequence):
 
             return Var(self.__model, key + self.__start)
 
-        raise Exception("Unknow type")
+        raise TypeError("Unknown type {}".format(type(key)))
 
     def __len__(self: "VVarList") -> int:
         return self.__model.solver.num_cols()
@@ -188,7 +188,7 @@ class VConstrList(Sequence):
         elif isinstance(key, slice):
             return self[key]
 
-        raise Exception("Use int or string as key")
+        raise TypeError("Use int, string or slice as key")
 
     def __len__(self) -> int:
         return self.__model.solver.num_rows()

--- a/mip/log.py
+++ b/mip/log.py
@@ -33,9 +33,8 @@ class ProgressLog:
         :attr:`~mip.model.ProgressLog.instance` and
         :attr:`~mip.model.ProgressLog.settings` attributes"""
         if not self.instance:
-            raise Exception(
-                "Enter model name (instance name) to save \
-                             experimental data."
+            raise ValueError(
+                "Enter model name (instance name) to save experimental data."
             )
         if not file_name:
             file_name = "{}-{}.plog".format(self.instance, self.settings)

--- a/mip/model.py
+++ b/mip/model.py
@@ -537,7 +537,7 @@ class Model:
         if path.lower().endswith(".sol") or path.lower().endswith(".mst"):
             mip_start = load_mipstart(path)
             if not mip_start:
-                raise Exception(
+                raise FileNotFoundError(
                     "File {} does not contains a valid feasible \
                                  solution.".format(
                         path
@@ -549,7 +549,7 @@ class Model:
                 if var is not None:
                     var_list.append((var, value))
             if not var_list:
-                raise Exception(
+                raise ValueError(
                     "Invalid variable(s) name(s) in \
                                  mipstart file {}".format(
                         path
@@ -571,7 +571,7 @@ class Model:
                 self.constrs.update_constrs(self.solver.num_rows())
                 return
 
-        raise Exception(
+        raise ValueError(
             "Use .lp, .mps, .sol or .mst as file extension \
                          to indicate the file format."
         )
@@ -619,7 +619,7 @@ class Model:
         ):
             self.solver.write(file_path)
         else:
-            raise Exception(
+            raise ValueError(
                 "Use .lp, .mps, .sol or .mst as file extension \
                              to indicate the file format."
             )
@@ -1193,7 +1193,8 @@ class Model:
 
     @sol_pool_size.setter
     def sol_pool_size(self: "Model", sol_pool_size: int):
-        assert sol_pool_size >= 1
+        if sol_pool_size < 1:
+            raise ValueError("Pool size must be at least one.")
         self.__sol_pool_size = sol_pool_size
 
     @property
@@ -1242,17 +1243,16 @@ class Model:
                 elif isinstance(o, Constr):
                     clist.append(o)
                 else:
-                    raise Exception(
+                    raise TypeError(
                         "Cannot handle removal of object of type "
-                        + type(o)
-                        + " from model."
+                        "{} from model".format(type(o))
                     )
             if vlist:
                 self.vars.remove(vlist)
             if clist:
                 self.constrs.remove(clist)
         else:
-            raise Exception(
+            raise TypeError(
                 "Cannot handle removal of object of type "
                 + type(objects)
                 + " from model."


### PR DESCRIPTION
Replaced a heap of raw Exceptions with more specific exceptions. This will allow users of the package to avoid catching broad ``Exception`` exceptions. Should be no issues with backwards compatibility as the new exceptions are also sub-classes of ``Exception``. The exceptions I've replaced them with are somewhat subjective and definitely need a review.

Replacing assert statements will change the exceptions they generate from an ``AssertionError`` to something else. So, not strictly backwards compatible. However, I really don't think anyone would have been writing code that relied on catching the rare assertion errors.