### PR TITLE
enforce types

### DIFF
--- a/mip/entities.py
+++ b/mip/entities.py
@@ -93,6 +93,8 @@ class LinExpr:
             result.add_expr(other)
         elif isinstance(other, numbers.Real):
             result.add_const(other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
         return result
 
     def __radd__(
@@ -109,6 +111,8 @@ class LinExpr:
             self.add_expr(other)
         elif isinstance(other, numbers.Real):
             self.add_const(other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
         return self
 
     def __sub__(
@@ -121,6 +125,8 @@ class LinExpr:
             result.add_expr(other, -1)
         elif isinstance(other, numbers.Real):
             result.add_const(-other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
         return result
 
     def __rsub__(
@@ -137,6 +143,8 @@ class LinExpr:
             self.add_expr(other, -1)
         elif isinstance(other, numbers.Real):
             self.add_const(-other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
         return self
 
     def __mul__(self: "LinExpr", other: Union[numbers.Real]) -> "LinExpr":
@@ -262,6 +270,8 @@ class LinExpr:
             self.add_expr(__expr, coeff)
         elif isinstance(__expr, numbers.Real):
             self.add_const(__expr)
+        else:
+            raise TypeError("type {} not supported".format(type(__expr)))
 
     def add_var(self: "LinExpr", var: "Var", coeff: float = 1):
         """adds a variable with a coefficient to the constraint"""
@@ -349,13 +359,14 @@ class LinExpr:
         """
         lhs = sum(coef * var.x for (var, coef) in self.__expr.items())
         rhs = -self.const
-        viol = 0.0
         if self.sense == "=":
             viol = abs(lhs - rhs)
         elif self.sense == "<":
             viol = max(lhs - rhs, 0.0)
         elif self.sense == ">":
             viol = max(rhs - lhs, 0.0)
+        else:
+            raise ValueError("Invalid sense {}".format(self.sense))
 
         return viol
 
@@ -411,6 +422,8 @@ class Constr:
             res += " <= {}".format(rhs)
         elif self.expr.sense == ">":
             res += " >= {}".format(rhs)
+        else:
+            raise ValueError("Invalid sense {}".format(self.expr.sense))
 
         return res
 
@@ -472,6 +485,8 @@ class Var:
             return other.__add__(self)
         elif isinstance(other, numbers.Real):
             return LinExpr([self], [1], other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
 
     def __radd__(self, other: Union["Var", LinExpr, numbers.Real]) -> LinExpr:
         return self.__add__(other)
@@ -483,6 +498,8 @@ class Var:
             return (-other).__iadd__(self)
         elif isinstance(other, numbers.Real):
             return LinExpr([self], [1], -other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
 
     def __rsub__(self, other: Union["Var", LinExpr, numbers.Real]) -> LinExpr:
         if isinstance(other, Var):
@@ -491,6 +508,8 @@ class Var:
             return other.__sub__(self)
         elif isinstance(other, numbers.Real):
             return LinExpr([self], [-1], other)
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
 
     def __mul__(self, other: Union[numbers.Real]) -> LinExpr:
         if not isinstance(other, numbers.Real):
@@ -519,6 +538,8 @@ class Var:
             if other != 0:
                 return LinExpr([self], [1], -1 * other, sense="=")
             return LinExpr([self], [1], sense="=")
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
 
     def __le__(self, other: Union["Var", LinExpr, numbers.Real]) -> LinExpr:
         if isinstance(other, Var):
@@ -529,6 +550,8 @@ class Var:
             if other != 0:
                 return LinExpr([self], [1], -1 * other, sense="<")
             return LinExpr([self], [1], sense="<")
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
 
     def __ge__(self, other: Union["Var", LinExpr, numbers.Real]) -> LinExpr:
         if isinstance(other, Var):
@@ -539,6 +562,8 @@ class Var:
             if other != 0:
                 return LinExpr([self], [1], -1 * other, sense=">")
             return LinExpr([self], [1], sense=">")
+        else:
+            raise TypeError("type {} not supported".format(type(other)))
 
     @property
     def name(self) -> str:

--- a/mip/model.py
+++ b/mip/model.py
@@ -175,6 +175,8 @@ class Model:
         elif isinstance(other, CutPool):
             for cut in other.cuts:
                 self.add_constr(cut)
+        else:
+            raise TypeError('type {} not supported'.format(type(other)))
 
         return self
 
@@ -686,6 +688,8 @@ class Model:
             self.solver.set_objective(LinExpr([objective], [1]))
         elif isinstance(objective, LinExpr):
             self.solver.set_objective(objective)
+        else:
+            raise TypeError('type {} not supported'.format(type(objective)))
 
     @property
     def verbose(self: "Model") -> int:

--- a/mip/model.py
+++ b/mip/model.py
@@ -176,7 +176,7 @@ class Model:
             for cut in other.cuts:
                 self.add_constr(cut)
         else:
-            raise TypeError('type {} not supported'.format(type(other)))
+            raise TypeError("type {} not supported".format(type(other)))
 
         return self
 
@@ -689,7 +689,7 @@ class Model:
         elif isinstance(objective, LinExpr):
             self.solver.set_objective(objective)
         else:
-            raise TypeError('type {} not supported'.format(type(objective)))
+            raise TypeError("type {} not supported".format(type(objective)))
 
     @property
     def verbose(self: "Model") -> int:


### PR DESCRIPTION
Previously types were not enforced when adding, multiplying etc.
This could easily lead to users ending up with ``None`` variables in in their program with no idea how they got there due to user mistakes, for example after neglecting to convert strings to numbers after importing from a file before using them.

The error messages I've added could certainly be made a bit more specific.

e.g. before:
<img width="140" alt="Screen Shot 2020-04-26 at 11 16 59 am" src="https://user-images.githubusercontent.com/33386122/80294812-e341fa80-87af-11ea-82a8-81bd1eb41490.png">

e.g. after:
<img width="631" alt="Screen Shot 2020-04-26 at 11 17 33 am" src="https://user-images.githubusercontent.com/33386122/80294813-e89f4500-87af-11ea-9f28-efb0029b5d41.png">
