### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, pypy3]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          # excludes pypy Windows
+          # excludes pypy Windows because only 32 bit pypy is supported.
           - os: windows-latest
             python-version: pypy3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
+    - name: debug echo
+      run: echo ${{ matrix.python-version }}
+
     - name: Install dependencies CPython
       if: ${{ matrix.python-version }} != 'pypy3'
       run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cffi pytest networkx numpy>=1.17.0 matplotlib
+        python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
         python -m pip install .
+
+    - name: list installed packages
+      run: python -m pip list
 
     - name: run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,11 +58,11 @@ jobs:
       run: echo ${{ matrix.python-version }}
 
     - name: Install dependencies CPython
-      if: ${{ matrix.python-version }} != 'pypy3'
+      if: matrix.python-version != 'pypy3'
       run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
 
     - name: Install dependencies PyPy
-      if: ${{ matrix.python-version }} == 'pypy3'
+      if: matrix.python-version == 'pypy3'
       run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,12 +55,12 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install dependencies CPython
-      run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
       if: ${{ matrix.python-version }} != 'pypy3'
+      run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
 
     - name: Install dependencies PyPy
-      run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
       if: ${{ matrix.python-version }} == 'pypy3'
+      run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
 
     - name: Install dependencies
       run: python -m pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,37 @@ on: [push, pull_request]
 
 jobs:
 
+  style:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: python -m pip install flake8 black
+
+      - name: check style with black
+        run: python -m black mip --line-length=89 --check
+
+      - name: check for unused imports with flake8
+        run: python -m flake8 mip --select=F401 --exclude=__init__.py
+
+
   test:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -26,7 +53,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install cffi pytest flake8 networkx numpy>=1.17.0 matplotlib
+        python -m pip install cffi pytest networkx numpy>=1.17.0 matplotlib
         python -m pip install .
 
     - name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,6 @@ jobs:
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
-    - name: debug echo
-      run: echo ${{ matrix.python-version }}
-
     - name: Install dependencies CPython
       if: matrix.python-version != 'pypy3'
       run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
@@ -65,7 +62,7 @@ jobs:
       if: matrix.python-version == 'pypy3'
       run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
 
-    - name: Install dependencies
+    - name: Install mip
       run: python -m pip install .
 
     - name: list installed packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [pypy3]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -47,6 +47,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Check python version
+      run: python -c "import sys; import platform; print('Python %s implementation %s on %s' % (sys.version, platform.python_implementation(), sys.platform))"
 
     - name: Upgrade pip
       run: python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,13 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install dependencies
-      run: |
-        python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
-        python -m pip install .
+      - run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
+        if: ${{ matrix.python-version }} != pypy3
+      - run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
+        if: ${{ matrix.python-version }} == pypy3
+
+    - name: Install dependencies
+      run: python -m pip install .
 
     - name: list installed packages
       run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
 
     - name: run tests
       run: |
-        python3 -m pytest test --verbose --color=yes --doctest-modules
-        python3 -m pytest mip --verbose --color=yes --doctest-modules --ignore="mip/gurobi.py"
+        python -m pytest test --verbose --color=yes --doctest-modules
+        python -m pytest mip --verbose --color=yes --doctest-modules --ignore="mip/gurobi.py"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+
+    - name: Install dependencies
+      run: |
+        python -m pip install cffi pytest flake8 networkx numpy>=1.17.0 matplotlib
+        python -m pip install .
+
+    - name: run tests
+      run: |
+        python3 -m pytest test --verbose --color=yes --doctest-modules
+        python3 -m pytest mip --verbose --color=yes --doctest-modules --ignore="mip/gurobi.py"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,10 @@ jobs:
       matrix:
         python-version: [pypy3]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          # excludes pypy Windows
+          - os: windows-latest
+            python-version: pypy3
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,13 @@ jobs:
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
-    - name: Install dependencies
-      - run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
-        if: ${{ matrix.python-version }} != pypy3
-      - run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
-        if: ${{ matrix.python-version }} == pypy3
+    - name: Install dependencies CPython
+      run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib
+      if: ${{ matrix.python-version }} != 'pypy3'
+
+    - name: Install dependencies PyPy
+      run: python -m pip install cffi pytest networkx "numpy>=1.17.0"
+      if: ${{ matrix.python-version }} == 'pypy3'
 
     - name: Install dependencies
       run: python -m pip install .

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -526,7 +526,7 @@ installing each one of the plants in auxiliary variables :math:`y`.
 .. literalinclude:: ../examples/plant_location.py
     :caption: Plant location problem with non-linear costs handled with Special Ordered Sets
     :linenos:
-    :lines: 12-109
+    :lines: 28-125
 
 The allocation of clients and plants in the optimal solution is shown bellow. This example uses 
 `Matplotlib <https://matplotlib.org/>`_ to draw the Figures.

--- a/examples/plant_location.py
+++ b/examples/plant_location.py
@@ -12,10 +12,18 @@ model the cost of installing each one of the plants.
 from math import sqrt, log
 from itertools import product
 from mip import Model, xsum, minimize, OptimizationStatus
-import matplotlib as mpl
 import sys
+
+# If running as a unit test, then skip if under pypy
+if hasattr(sys, '_called_from_test') and sys._called_from_test is True:
+    import platform
+    if 'pypy' in platform.python_implementation().lower():
+        import pytest
+        pytest.skip("Matplotlib installation not working under pypy")
+
 # Workaround for issues with python not being installed as a framework on mac
 # by using a different backend.
+import matplotlib as mpl
 if sys.platform == "darwin":  # OS X
     mpl.use('TkAgg')
 import matplotlib.pyplot as plt

--- a/examples/plant_location.py
+++ b/examples/plant_location.py
@@ -11,8 +11,14 @@ model the cost of installing each one of the plants.
 
 from math import sqrt, log
 from itertools import product
-import matplotlib.pyplot as plt
 from mip import Model, xsum, minimize, OptimizationStatus
+import matplotlib as mpl
+import sys
+# Workaround for issues with python not being installed as a framework on mac
+# by using a different backend.
+if sys.platform == "darwin":  # OS X
+    mpl.use('TkAgg')
+import matplotlib.pyplot as plt
 
 # possible plants
 F = [1, 2, 3, 4, 5, 6]

--- a/examples/plant_location.py
+++ b/examples/plant_location.py
@@ -9,9 +9,6 @@ to the non-linear function :math:`f(z)=1520 \log z`. Type 2 SOS will be used to
 model the cost of installing each one of the plants.
 """
 
-from math import sqrt, log
-from itertools import product
-from mip import Model, xsum, minimize, OptimizationStatus
 import sys
 
 # If running as a unit test, then skip if under pypy
@@ -23,10 +20,15 @@ if hasattr(sys, '_called_from_test') and sys._called_from_test is True:
 
 # Workaround for issues with python not being installed as a framework on mac
 # by using a different backend.
-import matplotlib as mpl
 if sys.platform == "darwin":  # OS X
+    import matplotlib as mpl
     mpl.use('TkAgg')
+    del mpl
+
 import matplotlib.pyplot as plt
+from math import sqrt, log
+from itertools import product
+from mip import Model, xsum, minimize, OptimizationStatus
 
 # possible plants
 F = [1, 2, 3, 4, 5, 6]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+import sys
+
+
+def pytest_configure(config):
+    import sys
+    sys._called_from_test = True
+
+
+def pytest_unconfigure(config):
+    if hasattr(sys, '_called_from_test'):
+        del sys._called_from_test


### PR DESCRIPTION
Use github actions for testing and format checking.
This is a trial in my mind - I propose leaving travis and appveyor in place for now until we're happy with actions and we can make a decision to switch over or not.

Related to conversation in #111 

I've also added pypy in, which required skipping the matplotlib test.
And python 3.5 on MacOS required a different matplotlib backend to work (https://github.com/uber/ludwig/issues/114 and https://github.com/uber/ludwig/commit/6b948ea9f0b2e78558fb51d2edd4d9c3558ff505)

Benefits of github actions
- Runs on forked repositories by default
- Completely unlimited
- Good support for macos and windows
- 20 concurrent builds versus Travis' 5 (or 8, was hard to find info)
