### PR TITLE
pip cache in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,17 @@ jobs:
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pythonpip
+
     - name: Install dependencies CPython
       if: matrix.python-version != 'pypy3'
       run: python -m pip install cffi pytest networkx "numpy>=1.17.0" matplotlib


### PR DESCRIPTION
This caches the pip files for github actions. Reduces the setup time for pypy down from 3+ mins to <20sec. For CPython the change is marginal. With this plus parallel pytest all tests run in about 8 minutes.