### PR TITLE
check if gurobi is available only once

### DIFF
--- a/mip/model.py
+++ b/mip/model.py
@@ -13,6 +13,12 @@ except ImportError:
     np = None
     logger.debug("Numpy not available", exc_info=True)
 
+try:
+    import mip.gurobi
+    has_gurobi = True
+except ImportError:
+    has_gurobi = False
+
 
 class Model:
     """ Mixed Integer Programming Model
@@ -87,15 +93,8 @@ class Model:
 
                 self.solver = mip.cbc.SolverCbc(self, name, sense)
             else:
-                # checking which solvers are available
-                try:
-                    import mip.gurobi
-
-                    has_gurobi = True
-                except ImportError:
-                    has_gurobi = False
-
                 if has_gurobi:
+                    import mip.gurobi
                     self.solver = mip.gurobi.SolverGurobi(self, name, sense)
                     self.solver_name = mip.GUROBI
                 else:

--- a/mip/model.py
+++ b/mip/model.py
@@ -15,6 +15,7 @@ except ImportError:
 
 try:
     import mip.gurobi
+
     has_gurobi = True
 except ImportError:
     has_gurobi = False
@@ -95,6 +96,7 @@ class Model:
             else:
                 if has_gurobi:
                     import mip.gurobi
+
                     self.solver = mip.gurobi.SolverGurobi(self, name, sense)
                     self.solver_name = mip.GUROBI
                 else:


### PR DESCRIPTION
As covered in #135, checking if Gurobi is available is done every time a `Model` is instantiated and is extremely slow. In my use case, a few milliseconds makes a substantial difference to total application runtime since I'm solving many small models.

This change does that check just once.