### PR TITLE
Fix import errors due to conditional absolute imports

### DIFF
--- a/mip/model.py
+++ b/mip/model.py
@@ -79,24 +79,24 @@ class Model:
 
             # creating a solver instance
             if self.solver_name.upper() in ["GUROBI", "GRB"]:
-                import mip.gurobi
+                from . import gurobi
 
-                self.solver = mip.gurobi.SolverGurobi(self, name, sense)
+                self.solver = gurobi.SolverGurobi(self, name, sense)
             elif self.solver_name.upper() == "CBC":
-                import mip.cbc
+                from . import cbc
 
-                self.solver = mip.cbc.SolverCbc(self, name, sense)
+                self.solver = cbc.SolverCbc(self, name, sense)
             else:
-                import mip.gurobi
+                from . import gurobi
 
-                if mip.gurobi.found:
+                if gurobi.found:
 
-                    self.solver = mip.gurobi.SolverGurobi(self, name, sense)
+                    self.solver = gurobi.SolverGurobi(self, name, sense)
                     self.solver_name = mip.GUROBI
                 else:
-                    import mip.cbc
+                    from . import cbc
 
-                    self.solver = mip.cbc.SolverCbc(self, name, sense)
+                    self.solver = cbc.SolverCbc(self, name, sense)
                     self.solver_name = mip.CBC
 
         # list of constraints and variables


### PR DESCRIPTION
There were import errors due to redefinition of the top-level `mip` module through conditional absolute imports when explicitly specifying the solver:

```pycon
>>> import mip
>>> mip.Model()
<mip.model.Model object at 0x10f576700>
>>> mip.Model(solver=mip.CBC)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../mip/model.py", line 104, in __init__
    self.constrs = mip.ConstrList(self)
UnboundLocalError: local variable 'mip' referenced before assignment
>>> mip.Model(solver=mip.GUROBI)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../mip/model.py", line 104, in __init__
    self.constrs = mip.ConstrList(self)
UnboundLocalError: local variable 'mip' referenced before assignment
```

This patch fixes these imprt errors through selective use of relative imports.