### PR TITLE
Incumbent progress

### DIFF
--- a/mip/callbacks.py
+++ b/mip/callbacks.py
@@ -130,7 +130,6 @@ class IncumbentUpdater:
     def update_incumbent(
         self,
         objective_value: float,
-        best_bound: float,
         solution: List[Tuple["mip.Var", float]],
     ) -> List[Tuple["mip.Var", float]]:
         """Method that is called when a new integer feasible solution is found

--- a/mip/callbacks.py
+++ b/mip/callbacks.py
@@ -1,7 +1,7 @@
 """Classes used in solver callbacks, for a bi-directional communication
 with the solver engine"""
 from collections import defaultdict
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import mip
 
 
@@ -131,7 +131,7 @@ class IncumbentUpdater:
         self,
         objective_value: float,
         solution: List[Tuple["mip.Var", float]],
-    ) -> List[Tuple["mip.Var", float]]:
+    ) -> Optional[List[Tuple["mip.Var", float]]]:
         """Method that is called when a new integer feasible solution is found
 
         Args:

--- a/mip/cbc.py
+++ b/mip/cbc.py
@@ -1087,7 +1087,7 @@ class SolverCbc(Solver):
 
             # TODO lmao what is the correct return value???
             # https://github.com/coin-or/Cbc/blob/9d5ff256842bb6c3baa50f62cd23f3de135572b0/test/CInterfaceTest.c#L889
-            return 1
+            return 0
 
         # cut callback
         @ffi.callback(

--- a/mip/cbc.py
+++ b/mip/cbc.py
@@ -1073,7 +1073,6 @@ class SolverCbc(Solver):
         """
         )
         def cbc_cut_callback(osi_solver, osi_cuts, app_data, depth, npass):
-            print(f"cut callback")
             if (
                 osi_solver == ffi.NULL
                 or osi_cuts == ffi.NULL

--- a/mip/model.py
+++ b/mip/model.py
@@ -113,6 +113,7 @@ class Model:
         self.__preprocess = -1
         self.__cuts_generator = None
         self.__lazy_constrs_generator = None
+        self.__incumbent_updater = None
         self.__start = None
         self.__threads = 0
         self.__lp_method = mip.LP_Method.AUTO
@@ -415,6 +416,7 @@ class Model:
         self.__cuts = 1
         self.__cuts_generator = None
         self.__lazy_constrs_generator = None
+        self.__incumbent_updater = None
         self.__start = []
         self._status = mip.OptimizationStatus.LOADED
         self.__threads = 0
@@ -1003,6 +1005,17 @@ class Model:
     @cuts_generator.setter
     def cuts_generator(self: "Model", cuts_generator: Optional["mip.ConstrsGenerator"]):
         self.__cuts_generator = cuts_generator
+
+    @property
+    def incumbent_updater(self: "Model") -> Optional["mip.IncumbentUpdater"]:
+        """TODO: docstring"""
+        return self.__incumbent_updater
+
+    @incumbent_updater.setter
+    def incumbent_updater(
+        self: "Model", incumbent_updater: Optional["mip.IncumbentUpdater"]
+    ):
+        self.__incumbent_updater = incumbent_updater
 
     @property
     def lazy_constrs_generator(


### PR DESCRIPTION
I've gone and had a stab at implementing the [``IncumbentUpdater``](https://docs.python-mip.com/en/latest/classes.html#incumbentupdater) functionality.

I've only implemented the ability to read the incumbent solution, not the ability to provide an updated solution back to the solver.

I've used it to make an animation of how the solution progresses as the solver runs - https://github.com/jurasofish/mip_incumbent

I'm opening this PR to start a discussion around whether this is useful and implemented okay (hmu if you know where they're hiding the docs for the CBC incumbent callback). not finished yet.

@h-g-s looks like you started on this a year or two ago but never got around to finishing it. Maybe you have some thoughts on what I've done?
