### PR TITLE
fixed closing bracket typo

### DIFF
--- a/mip/gurobi.py
+++ b/mip/gurobi.py
@@ -523,7 +523,7 @@ class SolverGurobi(Solver):
         obj_expr = xsum(
             obj[i] * self.model.vars[i]
             for i in range(self.num_cols())
-            if abs(obj[i] > 1e-20)
+            if abs(obj[i]) > 1e-20
         )
         obj_expr.sense = self.get_objective_sense
         return obj_expr


### PR DESCRIPTION
Fixed the below typo. 
Note that without the fix, all objective parameters with value < 1e-20 are discarded.
With the fix, all objective parameters with absolute value < 1e-20 are discarded.