### PR TITLE
Fix for `TypeError: can only concatenate str (not "type") to str`

### DIFF
--- a/mip/model.py
+++ b/mip/model.py
@@ -1427,8 +1427,7 @@ class Model:
         else:
             raise TypeError(
                 "Cannot handle removal of object of type "
-                + type(objects)
-                + " from model."
+                "{} from model".format(type(objects))
             )
 
     def translate(self: "Model", ref) -> Union[List[Any], Dict[Any, Any], "mip.Var"]:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 
@@ -1260,3 +1261,20 @@ def test_query_attributes_of_lin_expr(solver):
     assert constr_expr.violation is None
 
     m.optimize()
+
+
+@pytest.mark.parametrize("solver", SOLVERS)
+def test_remove(solver):
+    m = Model(solver_name=solver)
+    x = m.add_var("x")
+    constr = m.add_constr(x >= 0)
+    m.objective = x
+
+    with pytest.raises(TypeError, match=re.escape("Cannot handle removal of object of type <class 'NoneType'> from model")):
+        m.remove(None)
+
+    with pytest.raises(TypeError, match=re.escape("Cannot handle removal of object of type <class 'NoneType'> from model")):
+        m.remove([None])
+
+    m.remove(constr)
+    # TODO: Test the removal of variables (currently failing, see https://github.com/coin-or/python-mip/pull/288#discussion_r919215654)


### PR DESCRIPTION
An unexpected exception is encountered in the code below

```python
>>> import mip
>>> m = mip.Model()
>>> m.remove(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/markus/OpenSourceDev/python-mip/mip/model.py", line 1429, in remove
    "Cannot handle removal of object of type "
TypeError: can only concatenate str (not "type") to str
```

We would want it to throw `TypeError: Cannot handle removal of object of type <class 'NoneType'> from model` but while the error message is assembled, a different exception is encountered because you are trying to concatenate a string to a type.

Not a big issue but it's a quick fix :)