### PR TITLE
Small bugfix for Gurobi <10 libraries

### DIFF
--- a/mip/gurobi.py
+++ b/mip/gurobi.py
@@ -55,11 +55,11 @@ lib_path = None
 if "GUROBI_HOME" in environ:
     if platform.lower().startswith("win"):
         lib_path_dir = os.path.join(os.environ["GUROBI_HOME"], "bin", "*")
-        pattern = r'gurobi([0-9]{2,3}).dll'
+        pattern = r"gurobi([0-9]{2,3}).dll"
 
     else:
         lib_path_dir = os.path.join(os.environ["GUROBI_HOME"], "lib", "*")
-        pattern = r'libgurobi([0-9]{2,3})[.].*'
+        pattern = r"libgurobi([0-9]{2,3})[.].*"
 
     for libfile in glob(lib_path_dir):
         match = re.match(pattern, os.path.basename(libfile))


### PR DESCRIPTION
This PR addresses two small bugs:
1. The recent change to enable pickup of Gurobi 10.0 libraries has meant that all previous Gurobi versions are not findable, due to the glob-style matching. i.e. it now expects 3 digits like `libgurobi100.so`, not allowing for 2 digits like `libgurobi95.so` which many will still be using.

2. The code clause starting with "checking gurobi version" was not at the correct level of indentation. When no libfile was found from the globs, lib_path is still None, but gets called in lib_path.split and errors, instead of continuing to the next block of execution.

**Fix**: Rather than add more glob-style matches, this section is reworked with a very simple regex. The regex also allows extraction of the major_ver and minor_ver values, although these are not used.

I've tested this picks up the correct library for versions >=10 and <10 on Linux.