### PR TITLE
FIX: unbounded/infeasible status mismatch for CBC relaxed models

### DIFF
--- a/mip/cbc.py
+++ b/mip/cbc.py
@@ -1108,9 +1108,13 @@ class SolverCbc(Solver):
 
                 return OptimizationStatus.OPTIMAL
             if res == 2:
-                return OptimizationStatus.UNBOUNDED
-            if res == 3:
                 return OptimizationStatus.INFEASIBLE
+            if res == 3:
+                # Dual is infeasible. Primal can be infeasible or unbounded.
+                if cbclib.Cbc_isProvenInfeasible(self._model):
+                    return OptimizationStatus.INFEASIBLE
+                else:
+                    return OptimizationStatus.UNBOUNDED
             return OptimizationStatus.ERROR
 
         # adding cut generators


### PR DESCRIPTION
Hi, thanks for the awesome work on the library! I believe that I found a small bug in handling of result from CBC relaxed models.

Current version of `python-mip` (tested version 1.15.0 on Apple M1) does not work correctly for the relaxations of following ILPs

```{python}
import mip
m = mip.Model(solver_name="CBC")
x = m.add_var(var_type=mip.INTEGER)
m += x >= 1
m += x <= -1
m.objective = mip.maximize(x)
print(m.optimize(relax=True))
# returns OptimizationStatus.UNBOUNDED, although program is infeasible
```

```{python}
import mip
m = mip.Model(solver_name="CBC")
x = m.add_var(var_type=mip.INTEGER)
m.objective = mip.maximize(x)
print(m.optimize(relax=True))
# returns OptimizationStatus.INFEASIBLE, although program is unbounded
```

Comparing the `python-mip` CBC solver

https://github.com/coin-or/python-mip/blob/6044fc8f0414d71430e94b8a08573b695dc35b5a/mip/cbc.py#L1110-L1113

and actual `CBC` code for `Cbc_solveLinearProgram`

https://github.com/coin-or/Cbc/blob/f3a8af7b627ac068853d847c67d05614dcd99d39/src/Attic/Cbc_C_Interface.cpp#L1753-L1761

I concluded that the status codes for infeasible and unbounded programs are swapped in the `python-mip` code. Moreover, looking at CBC code, I believe that status 3 from `Cbc_solveLinearProgram` should be interpreted as *primal formulation is either unbounded or infeasible* (as dual infeasibility may lead primal to be either unbounded or infeasible); however, I could not find documentation for CBC on these status codes so I cannot be certain what the CBC developers meant by this status code. Therefore, I added a followup check for this status code to see whether the primal formulation is infeasible or unbounded.

I never worked with CBC before so hopefully I did not miss some detail.