### PR TITLE
Duplicate Variables Bandaid

### DIFF
--- a/mip/entities.py
+++ b/mip/entities.py
@@ -65,6 +65,9 @@ class LinExpr:
      a = 10*x1 + 7*x4
      print(a.x)
 
+    .. warning::
+    Do not pass identical objects in the ``variables`` argument when constructing
+    a LinExpr manually.   
     """
 
     __slots__ = ["__const", "__expr", "__sense"]
@@ -542,6 +545,8 @@ class Var:
         self, other: Union["mip.Var", LinExpr, numbers.Real]
     ) -> Union["mip.Var", LinExpr]:
         if isinstance(other, Var):
+            if id(self) == id(other):
+                return LinExpr([self], [2])
             return LinExpr([self, other], [1, 1])
         if isinstance(other, LinExpr):
             return other.__add__(self)
@@ -561,6 +566,8 @@ class Var:
         self, other: Union["mip.Var", LinExpr, numbers.Real]
     ) -> Union["mip.Var", LinExpr]:
         if isinstance(other, Var):
+            if id(self) == id(other):
+                return LinExpr([self], [0])
             return LinExpr([self, other], [1, -1])
         if isinstance(other, LinExpr):
             return (-other).__add__(self)
@@ -575,6 +582,8 @@ class Var:
         self, other: Union["mip.Var", LinExpr, numbers.Real]
     ) -> Union["mip.Var", LinExpr]:
         if isinstance(other, Var):
+            if id(self) == id(other):
+                return LinExpr([self], [0])
             return LinExpr([self, other], [-1, 1])
         if isinstance(other, LinExpr):
             return other.__sub__(self)
@@ -603,6 +612,8 @@ class Var:
 
     def __eq__(self, other) -> LinExpr:
         if isinstance(other, Var):
+            if id(self) == id(other):
+                return LinExpr([self], [0], sense="=")
             return LinExpr([self, other], [1, -1], sense="=")
         if isinstance(other, LinExpr):
             return LinExpr([self], [1]) == other
@@ -613,6 +624,8 @@ class Var:
 
     def __le__(self, other: Union["mip.Var", LinExpr, numbers.Real]) -> LinExpr:
         if isinstance(other, Var):
+            if id(self) == id(other):
+                return LinExpr([self], [0], sense="<")
             return LinExpr([self, other], [1, -1], sense="<")
         if isinstance(other, LinExpr):
             return LinExpr([self], [1]) <= other
@@ -623,6 +636,8 @@ class Var:
 
     def __ge__(self, other: Union["mip.Var", LinExpr, numbers.Real]) -> LinExpr:
         if isinstance(other, Var):
+            if id(self) == id(other):
+                return LinExpr([self], [0], sense=">")
             return LinExpr([self, other], [1, -1], sense=">")
         if isinstance(other, LinExpr):
             return LinExpr([self], [1]) >= other

--- a/test/mip_test.py
+++ b/test/mip_test.py
@@ -4,6 +4,7 @@ from itertools import product
 from os import environ
 
 import networkx as nx
+from mip.entities import LinExpr
 import mip.gurobi
 import mip.highs
 from mip import Model, xsum, OptimizationStatus, MAXIMIZE, BINARY, INTEGER
@@ -576,6 +577,28 @@ class TestAPI(object):
 
         model.objective = 1
         assert model.objective_const == 1
+
+
+@skip_on(NotImplementedError)
+@pytest.mark.parametrize("solver", SOLVERS)
+@pytest.mark.parametrize("constraint, lb, ub", [
+    (lambda x: x + x >= 3, 1, 2),
+    (lambda x: x - x >= 0, 1, 2),
+    (lambda x: x == x, 1, 2),
+    (lambda x: x >= x, 1, 2),
+    (lambda x: x <= x, -2, -1),
+    # (lambda x: LinExpr([x, x, x], [2, -1, -1], sense="="), 1, 2),
+])
+def test_identical_vars(solver: str, constraint, lb, ub):
+    """Try if constraints are correctly added when variables are identical"""
+    m = Model(solver_name=solver)
+    x = m.add_var(name="x", lb=lb, ub=ub, obj=1)
+    
+    m.add_constr(constraint(x))
+
+    m.optimize()
+    assert m.status == OptimizationStatus.OPTIMAL
+    assert lb - TOL <= x.x <= ub + TOL
 
 
 @skip_on(NotImplementedError)


### PR DESCRIPTION
Attempting to fix #396. If we have two identical objects in the `Var` overrides, the previous code would allow the `LinExpr` constructor to void anything but the last coefficient.

I also added the relevant tests, which now pass. The last constraint would fail, because I only modified the `Var` functions, not the constructor itself.

---

Alternative:
```diff
diff --git a/mip/entities.py b/mip/entities.py
index fcd3ecd..71091b5 100644
--- a/mip/entities.py
+++ b/mip/entities.py
@@ -92,7 +92,8 @@ class LinExpr:
                     "You should pass eiter 'expr' or 'variables and coeffs' to the"
                     "constructor, not the three simultaneously."
                 )
-            self.__expr = dict(zip(variables, coeffs))
+            for var, coef in zip(variables, coeffs):
+                self.add_var(var, coef)
 
         elif expr is not None:
             self.__expr = expr.copy()
```

However, this would tank a performance slightly if users create the `LinExpr` manually. For [this benchmark](https://github.com/coin-or/python-mip/blob/0ccb81115543e737ab74a4f1309891ce5650c8d5/examples/inplace_linexpr_creation.py#L72), the `using_lists` method runs in 0.71s vs 0.33s for `n=2000`. Considering the last change was made due to performance reasons, I did not want to revert this right away, but feel free to approve this.
